### PR TITLE
Fix: Prevent Back Navigation to Basic Details Screen After Proceeding [feature/prevent-back-navigation](#49)

### DIFF
--- a/Frontend/src/Screens/BasicDetailsScreen.jsx
+++ b/Frontend/src/Screens/BasicDetailsScreen.jsx
@@ -37,7 +37,10 @@ export default function BasicDetailsScreen() {
     setErrors(newErrors);
 
     if (Object.keys(newErrors).length === 0) {
-      navigation.replace("MainTabs");
+      navigation.reset({
+        index: 0,
+        routes: [{ name: "MainTabs" }],
+      });
     }
   };
 


### PR DESCRIPTION

<!-- What issue does this PR close? -->
Closes #49 

---

## 📝 Description
This PR prevents users from navigating back to the Basic Details screen after proceeding by updating the navigation stack and disabling back gestures. The changes ensure a smoother and more structured user flow, preventing unintended modifications to user data.

---

## 🔧 Changes Made
- Updated `BasicDetailsScreen.jsx` to replace `navigation.replace` with `navigation.reset` to manage the navigation stack effectively.
- Disabled back gestures on screens where backward navigation is not desired.

---

## 🎥 Video Evidence
- **📌 Before Fix:** 

https://github.com/user-attachments/assets/2aea973e-b01d-420f-a210-aa9ab5fbe26f


- **📌 After Fix:** 

https://github.com/user-attachments/assets/09b03553-296e-4d3c-87be-a274a09c9e0d



---

## 🤝 Collaboration
No collaboration.

---

### ✅ Checklist
- [x] I have read the contributing guidelines.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if applicable).
- [x] Any dependent changes have been merged and published in downstream modules.



