### PR TITLE
Add Code of Conduct to complement contribution guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -33,7 +33,8 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported
+to the project maintainers via GitHub issues or by contacting the AOSSIE organization maintainers. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
@@ -71,4 +72,8 @@ This Code of Conduct is adapted from the Contributor Covenant, version 2.1, avai
 
 Community Impact Guidelines were inspired by Mozilla’s code of conduct enforcement ladder.
 
-For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.
+For answers to common questions about this code of conduct, see the
+[Contributor Covenant FAQ](https://www.contributor-covenant.org/faq).
+Translations are available at
+[Contributor Covenant Translations](https://www.contributor-covenant.org/translations).
+


### PR DESCRIPTION
This PR adds a CODE_OF_CONDUCT.md using the Contributor Covenant template
to clearly define community standards and reporting procedures.

Closes #121

Proceeding assuming this is okay — happy to adjust based on feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Code of Conduct document to establish community standards and expectations for all contributors and participants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->