### PR TITLE
Added Fix(drawer): Navigate to AllTasks screen correctly

### DIFF
--- a/Frontend/src/Screens/CustomDrawer.jsx
+++ b/Frontend/src/Screens/CustomDrawer.jsx
@@ -64,7 +64,7 @@ export default function CustomDrawer({ children }) {
           <TouchableOpacity onPress={() => navigateTo('Home')} style={styles.link}>
             <Text>Home</Text>
           </TouchableOpacity>
-          <TouchableOpacity onPress={() => navigateTo('Tasks')} style={styles.link}>
+          <TouchableOpacity onPress={() => navigateTo('AllTasks')} style={styles.link}>
             <Text>Tasks & AI Recommendations</Text>
           </TouchableOpacity>
           <TouchableOpacity onPress={() => navigateTo('Weight')} style={styles.link}>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #


## 📝 Description

This PR fixes the drawer “Tasks & AI Recommendations” button so that it correctly navigates to the AllTasks screen. Previously, clicking the button did nothing because the navigation string did not match the stack screen name.

## 🔧 Changes Made

- Updated `CustomDrawer.jsx`:
  - Changed `navigateTo('Tasks')` to `navigateTo('AllTasks')` to match the stack screen name.
- Verified all other drawer buttons and navigation flows still work correctly.

## 📷 Screenshots or Visual Changes (if applicable)

Clicking the drawer “Tasks & AI Recommendations” button now navigates correctly to the AllTasks screen.
[Demo Video](https://github.com/user-attachments/assets/dc2fc1f6-7d0d-48f3-b579-b8383b868c06)


## 🤝 Collaboration

<!-- If you collaborated with someone on this pull request, mention their GitHub username or name here. -->
Collaborated with: N/A


### ✅ Checklist
- [x] I have read the contributing guidelines.
- [x] I have tested the fix locally; navigation works.
- [ ] I have added necessary documentation (if applicable).
- [x] Any dependent changes have been merged and published in downstream modules.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation routing for the "Tasks & AI Recommendations" menu item to ensure users are directed to the correct tasks view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->