### PR TITLE
Add AOSSIE YouTube channel link to social handles in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 <img src="https://img.shields.io/twitter/follow/AOSSIE" alt="X (formerly Twitter) Badge"/></a>
 &nbsp;&nbsp;
 <!-- YouTube -->
-<a href="https://www.youtube.com/@AOSSIE">
+<a href="https://www.youtube.com/@AOSSIE-Org">
 <img src="https://img.shields.io/youtube/channel/subscribers/UCZU5RJYz42z3T3Q4P4Y8XQ?style=flat&logo=youtube&logoColor=white&logoSize=auto&label=YouTube&labelColor=FF0000&color=FF0000" alt="YouTube Badge"/></a>
 &nbsp;&nbsp;
 <!-- Discord -->

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@
 <a href="https://twitter.com/aossie_org">
 <img src="https://img.shields.io/twitter/follow/AOSSIE" alt="X (formerly Twitter) Badge"/></a>
 &nbsp;&nbsp;
+<!-- YouTube -->
+<a href="https://www.youtube.com/@AOSSIE">
+<img src="https://img.shields.io/youtube/channel/subscribers/UCZU5RJYz42z3T3Q4P4Y8XQ?style=flat&logo=youtube&logoColor=white&logoSize=auto&label=YouTube&labelColor=FF0000&color=FF0000" alt="YouTube Badge"/></a>
+&nbsp;&nbsp;
 <!-- Discord -->
 <a href="https://discord.gg/hjUhu33uAn">
 <img src="https://img.shields.io/discord/995968619034984528?style=flat&logo=discord&logoColor=white&logoSize=auto&label=Discord&labelColor=5865F2&color=57F287" alt="Discord Badge"/></a>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 &nbsp;&nbsp;
 <!-- YouTube -->
 <a href="https://www.youtube.com/@AOSSIE-Org">
-<img src="https://img.shields.io/youtube/channel/subscribers/UCZU5RJYz42z3T3Q4P4Y8XQ?style=flat&logo=youtube&logoColor=white&logoSize=auto&label=YouTube&labelColor=FF0000&color=FF0000" alt="YouTube Badge"/></a>
+<img src="https://img.shields.io/badge/YouTube-Channel-FF0000?style=flat&logo=youtube&logoColor=white" alt="YouTube Badge"/>
 &nbsp;&nbsp;
 <!-- Discord -->
 <a href="https://discord.gg/hjUhu33uAn">


### PR DESCRIPTION
This PR adds the official AOSSIE YouTube channel link to the social handles section in the README.md file. The link is placed consistently with the existing Twitter and Discord links, using the same formatting and badge style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a YouTube badge and link to the social handles section (placed between Twitter and Discord), expanding visible social platform links in the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->